### PR TITLE
Feature: Add handler for load-more in topic screen

### DIFF
--- a/console_inject.js
+++ b/console_inject.js
@@ -5,6 +5,10 @@ function mutationCallback(mutationList, observer) {
         if ((typeof node.classList !== "undefined") && node.classList.contains("view-more-button-container")) {
           intersectionObserver.observe(node.querySelector(".view-more-button"));
         }
+
+        if ((typeof node.classList !== "undefined") && node.classList.contains("load-more-bar")) {
+          intersectionObserver.observe(node.querySelector(".load-more-button"));
+        }     
       });
     }
   });


### PR DESCRIPTION
# Brief
Autoload answers hidden in view-topic section.
<img width="1059" alt="Captura de pantalla 2019-03-27 a la(s) 12 58 30" src="https://user-images.githubusercontent.com/17008744/55091775-34089080-5090-11e9-9d4c-6deddc587e0b.png">
 

(I'm not sure if into-thread is into the scope)